### PR TITLE
use django.utils.six

### DIFF
--- a/appconf/base.py
+++ b/appconf/base.py
@@ -1,8 +1,7 @@
 import sys
 
-import six
-
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 
 from .utils import import_attribute
 


### PR DESCRIPTION
this app is working in django, so no need to add additional dependency when it exist. using django.utils.six is better.